### PR TITLE
Fix response body stream already read error in capacity analysis

### DIFF
--- a/app/capacity-optimizer/page.tsx
+++ b/app/capacity-optimizer/page.tsx
@@ -150,12 +150,12 @@ export default function CapacityOptimizer() {
         }),
       });
 
-      const results = await response.json();
-
       if (!response.ok) {
-        throw new Error(results.error || 'Failed to run capacity analysis');
+        const errorData = await response.json();
+        throw new Error(errorData.error || 'Failed to run capacity analysis');
       }
 
+      const results = await response.json();
       setAnalysisResults(results);
       setAnalysisError(null);
     } catch (error) {


### PR DESCRIPTION
## Purpose
Fix the "body stream already read" error that occurs when running capacity analysis. The user was encountering this error which prevented the capacity analysis feature from working properly.

## Code changes
- Moved the `response.json()` call for error handling inside the error condition block
- Ensured the response body is only read once - either for error data when the response fails, or for results when the response succeeds
- This prevents the "body stream already read" error that was occurring when trying to read the response body multiple times

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 23`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2b0e10ddb207455f9e730942e3cdf7bc/stellar-landing)

👀 [Preview Link](https://2b0e10ddb207455f9e730942e3cdf7bc-stellar-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2b0e10ddb207455f9e730942e3cdf7bc</projectId>-->
<!--<branchName>stellar-landing</branchName>-->