### PR TITLE
Fix infinite loading spinner in project fetch

### DIFF
--- a/components/ProjectScenarioManager.tsx
+++ b/components/ProjectScenarioManager.tsx
@@ -77,24 +77,23 @@ export default function ProjectScenarioManager({
 
   useEffect(() => {
     let abortController: AbortController | null = null;
-    let timeoutId: NodeJS.Timeout | null = null;
 
-    // Add a small delay to ensure the app is fully loaded
-    timeoutId = setTimeout(() => {
-      if (isMounted) {
-        try {
-          abortController = new AbortController();
-          fetchProjects(abortController.signal);
-        } catch (error) {
+    const initializeFetch = async () => {
+      if (!isMounted) return;
+
+      try {
+        abortController = new AbortController();
+        await fetchProjects(abortController.signal);
+      } catch (error) {
+        if (isMounted && !abortController?.signal.aborted) {
           console.warn('Error initializing project fetch:', error);
         }
       }
-    }, 100);
+    };
+
+    initializeFetch();
 
     return () => {
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
       if (abortController && !abortController.signal.aborted) {
         try {
           abortController.abort('Component unmounting');
@@ -105,7 +104,7 @@ export default function ProjectScenarioManager({
       }
       setIsMounted(false);
     };
-  }, [isMounted]);
+  }, []);
 
   const fetchProjects = async (signal?: AbortSignal) => {
     if (!isMounted) return;


### PR DESCRIPTION
## Purpose
Fix the issue where the loading projects spinner would not stop spinning, as reported by the user. The problem was caused by improper handling of component mounting state and abort signals during async operations.

## Code changes
- **Removed timeout delay**: Eliminated the 100ms setTimeout that was causing timing issues with the fetch initialization
- **Improved abort signal handling**: Replaced `isMounted` checks with proper `signal?.aborted` checks throughout the fetch process
- **Simplified useEffect dependencies**: Changed dependency array from `[isMounted]` to `[]` to prevent unnecessary re-runs
- **Enhanced error handling**: Added abort signal checks in the scenarios fetch loop and improved error boundary conditions
- **Cleaner async flow**: Converted the initialization logic to use async/await pattern for better error handling

These changes ensure that the loading state is properly managed and the spinner stops when data fetching completes or is aborted.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 33`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2b0e10ddb207455f9e730942e3cdf7bc/stellar-works)

👀 [Preview Link](https://2b0e10ddb207455f9e730942e3cdf7bc-stellar-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2b0e10ddb207455f9e730942e3cdf7bc</projectId>-->
<!--<branchName>stellar-works</branchName>-->